### PR TITLE
Add Dockerfile

### DIFF
--- a/Docker file
+++ b/Docker file
@@ -1,0 +1,13 @@
+FROM buildpack-deps:jessie
+
+ADD . /tcpkali
+
+RUN apt-get update && apt-get install -y bison flex
+
+RUN cd /tcpkali && \
+  test -f configure || autoreconf -iv && \
+  ./configure && \
+  make && \
+  make install
+
+CMD ["tcpkali"]


### PR DESCRIPTION
This PR adds a Dockerfile to easily use tcpkali without installing all dependencies.

If you need a bash, run `docker build -t tcpkali . && docker run -it tcpkali bash`. You then have the `tcpkali` command available.