### PR TITLE
SSL fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ m4_include([deps/libstatsd/libstatsd.m4])
 
 dnl Import locally defined macros.
 m4_include([m4/ax_check_compile_flag.m4])
+m4_include([m4/ax_check_openssl.m4])
 m4_include([m4/ax_make_optional_include.m4])
 
 AX_CHECK_GNU_STYLE_OPTIONAL_INCLUDE()
@@ -115,21 +116,19 @@ AC_ARG_ENABLE([tsan],
     dnl We can't do anything about this message in GCC; use clang.
   ])
 
-AC_ARG_WITH([openssl],
-    [AS_HELP_STRING([--with-openssl],
-      [Enable support for openssl])],
-    [],
-    [with_openssl=no])
-  AS_IF([test "x$with_openssl" != xno], [
-     AC_CHECK_LIB(crypto, CRYPTO_new_ex_data, [], [AC_MSG_ERROR([library 'crypto' is required for OpenSSL])])
-     FOUND_SSL_LIB="no"
-     AC_CHECK_LIB(ssl, OPENSSL_init_ssl, [FOUND_SSL_LIB="yes"])
-     AC_CHECK_LIB(ssl, SSL_library_init, [FOUND_SSL_LIB="yes"])
-     AS_IF([test "x$FOUND_SSL_LIB" = xno],
-       [AC_MSG_ERROR([library 'ssl' is required for OpenSSL])],
-       [AC_DEFINE([HAVE_OPENSSL], [1], [Define to 1 if you have OpenSSL])
-        LIBS="-lssl $LIBS"])
-  ])
+AX_CHECK_OPENSSL(
+    [AC_DEFINE([HAVE_OPENSSL], [1], [Define to 1 if you have OpenSSL])
+TK_LIBS="${OPENSSL_LIBS}"
+TK_LDFLAGS="${OPENSSL_LDFLAGS}"
+TK_CPPFLAGS="${OPENSSL_INCLUDES}"
+AC_CHECK_FUNC(SSL_CTX_set_ecdh_auto,
+        [AC_DEFINE([HAVE_SSL_CTX_SET_ECDH_AUTO], [1],
+            [Define to 1 if you have SSL_CTX_set_ecdh_auto function defined in OpenSSL])])
+    ],
+    [])
+AC_SUBST(TK_LIBS)
+AC_SUBST(TK_LDFLAGS)
+AC_SUBST(TK_CPPFLAGS)
 
 dnl We use pandoc to generate documentation.
 AC_PATH_PROG([PANDOC], pandoc)

--- a/doc/tcpkali.1
+++ b/doc/tcpkali.1
@@ -129,6 +129,24 @@ Use RFC6455 WebSocket transport.
 .RS
 .RE
 .TP
+.B \-\-ssl
+Enable Transport Layer Security (TLS, formerly known as SSL) for
+client\-side and server\-side connections.
+.RS
+.RE
+.TP
+.B \-\-ssl\-cert \f[I]filename\f[]
+The X.509 certificate file for TLS termination.
+Default is "cert.pem".
+.RS
+.RE
+.TP
+.B \-\-ssl\-key \f[I]filename\f[]
+The private key file for TLS termination.
+Default is "key.pem".
+.RS
+.RE
+.TP
 .B \-H, \-\-header
 Add HTTP header into the WebSocket handshake.
 .RS

--- a/doc/tcpkali.man.md
+++ b/doc/tcpkali.man.md
@@ -82,6 +82,15 @@ open more than 64k connections to destinations.
 --ws, --websocket
 :   Use RFC6455 WebSocket transport.
 
+--ssl
+:   Enable Transport Layer Security (TLS, formerly known as SSL) for client-side and server-side connections.
+
+--ssl-cert *filename*
+:   The X.509 certificate file for TLS termination. Default is "cert.pem".
+
+--ssl-key *filename*
+:   The private key file for TLS termination. Default is "key.pem".
+
 -H, --header
 :   Add HTTP header into the WebSocket handshake.
 

--- a/m4/ax_check_openssl.m4
+++ b/m4/ax_check_openssl.m4
@@ -1,0 +1,124 @@
+# ===========================================================================
+#     https://www.gnu.org/software/autoconf-archive/ax_check_openssl.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_OPENSSL([action-if-found[, action-if-not-found]])
+#
+# DESCRIPTION
+#
+#   Look for OpenSSL in a number of default spots, or in a user-selected
+#   spot (via --with-openssl).  Sets
+#
+#     OPENSSL_INCLUDES to the include directives required
+#     OPENSSL_LIBS to the -l directives required
+#     OPENSSL_LDFLAGS to the -L or -R flags required
+#
+#   and calls ACTION-IF-FOUND or ACTION-IF-NOT-FOUND appropriately
+#
+#   This macro sets OPENSSL_INCLUDES such that source files should use the
+#   openssl/ directory in include directives:
+#
+#     #include <openssl/hmac.h>
+#
+# LICENSE
+#
+#   Copyright (c) 2009,2010 Zmanda Inc. <http://www.zmanda.com/>
+#   Copyright (c) 2009,2010 Dustin J. Mitchell <dustin@zmanda.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 10
+
+AU_ALIAS([CHECK_SSL], [AX_CHECK_OPENSSL])
+AC_DEFUN([AX_CHECK_OPENSSL], [
+    found=false
+    AC_ARG_WITH([openssl],
+        [AS_HELP_STRING([--with-openssl=DIR],
+            [root of the OpenSSL directory])],
+        [
+            case "$withval" in
+            "" | y | ye | yes | n | no)
+            AC_MSG_ERROR([Invalid --with-openssl value])
+              ;;
+            *) ssldirs="$withval"
+              ;;
+            esac
+        ], [
+            # if pkg-config is installed and openssl has installed a .pc file,
+            # then use that information and don't search ssldirs
+            AC_CHECK_TOOL([PKG_CONFIG], [pkg-config])
+            if test x"$PKG_CONFIG" != x""; then
+                OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
+                if test $? = 0; then
+                    OPENSSL_LIBS=`$PKG_CONFIG openssl --libs-only-l 2>/dev/null`
+                    OPENSSL_INCLUDES=`$PKG_CONFIG openssl --cflags-only-I 2>/dev/null`
+                    found=true
+                fi
+            fi
+
+            # no such luck; use some default ssldirs
+            if ! $found; then
+                ssldirs="/usr/local/ssl /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /usr"
+            fi
+        ]
+        )
+
+
+    # note that we #include <openssl/foo.h>, so the OpenSSL headers have to be in
+    # an 'openssl' subdirectory
+
+    if ! $found; then
+        OPENSSL_INCLUDES=
+        for ssldir in $ssldirs; do
+            AC_MSG_CHECKING([for openssl/ssl.h in $ssldir])
+            if test -f "$ssldir/include/openssl/ssl.h"; then
+                OPENSSL_INCLUDES="-I$ssldir/include"
+                OPENSSL_LDFLAGS="-L$ssldir/lib"
+                OPENSSL_LIBS="-lssl -lcrypto"
+                found=true
+                AC_MSG_RESULT([yes])
+                break
+            else
+                AC_MSG_RESULT([no])
+            fi
+        done
+
+        # if the file wasn't found, well, go ahead and try the link anyway -- maybe
+        # it will just work!
+    fi
+
+    # try the preprocessor and linker with our new flags,
+    # being careful not to pollute the global LIBS, LDFLAGS, and CPPFLAGS
+
+    AC_MSG_CHECKING([whether compiling and linking against OpenSSL works])
+    echo "Trying link with OPENSSL_LDFLAGS=$OPENSSL_LDFLAGS;" \
+        "OPENSSL_LIBS=$OPENSSL_LIBS; OPENSSL_INCLUDES=$OPENSSL_INCLUDES" >&AS_MESSAGE_LOG_FD
+
+    save_LIBS="$LIBS"
+    save_LDFLAGS="$LDFLAGS"
+    save_CPPFLAGS="$CPPFLAGS"
+    LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
+    LIBS="$OPENSSL_LIBS $LIBS"
+    CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([#include <openssl/ssl.h>], [SSL_new(NULL)])],
+        [
+            AC_MSG_RESULT([yes])
+            $1
+        ], [
+            AC_MSG_RESULT([no])
+            $2
+        ])
+    CPPFLAGS="$save_CPPFLAGS"
+    LDFLAGS="$save_LDFLAGS"
+    LIBS="$save_LIBS"
+
+    AC_SUBST([OPENSSL_INCLUDES])
+    AC_SUBST([OPENSSL_LIBS])
+    AC_SUBST([OPENSSL_LDFLAGS])
+])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,8 @@ bin_PROGRAMS = tcpkali
 AM_YFLAGS = -d
 AM_LFLAGS = -s
 
-tcpkali_CPPFLAGS = -I$(top_srcdir)/deps/libev \
+tcpkali_CPPFLAGS = $(TK_CPPFLAGS) \
+                   -I$(top_srcdir)/deps/libev \
                    -I$(top_srcdir)/deps/libcows \
                    -I$(top_srcdir)/deps/libstatsd/src \
                    -I$(top_srcdir)/deps/HdrHistogram \
@@ -36,7 +37,7 @@ tcpkali_SOURCES = \
                 tcpkali_ssl.c tcpkali_ssl.h               \
                 tcpkali_connection.c tcpkali_connection.h \
                 tcpkali.c tcpkali.h
-tcpkali_LDFLAGS = -L$(libdir) $(LIBUV)
+tcpkali_LDFLAGS = $(TK_LDFLAGS) $(TK_LIBS) -L$(libdir) $(LIBUV)
 tcpkali_LDADD = $(top_builddir)/deps/libev/libev.la \
                 $(top_builddir)/deps/libcows/libcows.la \
                 $(top_builddir)/deps/pcg-c-basic/libpcg32.la \

--- a/src/tcpkali_connection.c
+++ b/src/tcpkali_connection.c
@@ -35,19 +35,17 @@ ssl_setup(struct connection UNUSED *conn, int UNUSED sockfd,
 #ifdef  HAVE_SSL_CTX_SET_ECDH_AUTO
             SSL_CTX_set_ecdh_auto(conn->ssl_ctx, 1);
 #endif
-            if(SSL_CTX_use_certificate_file(conn->ssl_ctx,
-                                            ssl_cert ? ssl_cert : "cert.pem",
+            if(SSL_CTX_use_certificate_file(conn->ssl_ctx, ssl_cert,
                                             SSL_FILETYPE_PEM)
                <= 0) {
-                fprintf(stderr, "%s: %s\n", ssl_cert ? ssl_cert : "cert.pem",
+                fprintf(stderr, "%s: %s\n", ssl_cert,
                         ERR_error_string(ERR_get_error(), NULL));
                 exit(1);
             }
-            if(SSL_CTX_use_PrivateKey_file(conn->ssl_ctx,
-                                           ssl_key ? ssl_key : "key.pem",
+            if(SSL_CTX_use_PrivateKey_file(conn->ssl_ctx, ssl_key,
                                            SSL_FILETYPE_PEM)
                <= 0) {
-                fprintf(stderr, "%s: %s\n", ssl_key ? ssl_key : "key.pem",
+                fprintf(stderr, "%s: %s\n", ssl_key,
                         ERR_error_string(ERR_get_error(), NULL));
                 exit(1);
             }

--- a/src/tcpkali_connection.c
+++ b/src/tcpkali_connection.c
@@ -32,7 +32,9 @@ ssl_setup(struct connection UNUSED *conn, int UNUSED sockfd,
         exit(1);
     } else {
         if(conn->conn_type == CONN_INCOMING) {
+#ifdef  HAVE_SSL_CTX_SET_ECDH_AUTO
             SSL_CTX_set_ecdh_auto(conn->ssl_ctx, 1);
+#endif
             if(SSL_CTX_use_certificate_file(conn->ssl_ctx,
                                             ssl_cert ? ssl_cert : "cert.pem",
                                             SSL_FILETYPE_PEM)


### PR DESCRIPTION
 * Fixes around linking (extended search for the OpenSSL library).
 * Attempt to build with SSL by default.
 * Documentation fixes.
 * Fixes in command line parsing and option verification.