### PR TITLE
Fix message counter

### DIFF
--- a/src/tcpkali.c
+++ b/src/tcpkali.c
@@ -890,7 +890,7 @@ main(int argc, char **argv) {
     int no_message_to_send =
         (0 == message_collection_estimate_size(
                   &engine_params.message_collection, MSK_PURPOSE_MESSAGE,
-                  MSK_PURPOSE_MESSAGE, MCE_MINIMUM_SIZE, WS_SIDE_CLIENT));
+                  MSK_PURPOSE_MESSAGE, MCE_MINIMUM_SIZE, WS_SIDE_CLIENT, 0));
 
     /*
      * Message marker mode can be explicitly enabled via --message-marker,
@@ -938,7 +938,7 @@ main(int argc, char **argv) {
        && no_message_to_send) {
         if(message_collection_estimate_size(
                &engine_params.message_collection, MSK_PURPOSE_MESSAGE,
-               MSK_PURPOSE_MESSAGE, MCE_MAXIMUM_SIZE, WS_SIDE_CLIENT)
+               MSK_PURPOSE_MESSAGE, MCE_MAXIMUM_SIZE, WS_SIDE_CLIENT, 1)
            > 0) {
             fprintf(stderr,
                     "--message may resolve "

--- a/src/tcpkali.c
+++ b/src/tcpkali.c
@@ -890,7 +890,7 @@ main(int argc, char **argv) {
     int no_message_to_send =
         (0 == message_collection_estimate_size(
                   &engine_params.message_collection, MSK_PURPOSE_MESSAGE,
-                  MSK_PURPOSE_MESSAGE, MCE_MINIMUM_SIZE));
+                  MSK_PURPOSE_MESSAGE, MCE_MINIMUM_SIZE, WS_SIDE_CLIENT));
 
     /*
      * Message marker mode can be explicitly enabled via --message-marker,
@@ -938,7 +938,7 @@ main(int argc, char **argv) {
        && no_message_to_send) {
         if(message_collection_estimate_size(
                &engine_params.message_collection, MSK_PURPOSE_MESSAGE,
-               MSK_PURPOSE_MESSAGE, MCE_MAXIMUM_SIZE)
+               MSK_PURPOSE_MESSAGE, MCE_MAXIMUM_SIZE, WS_SIDE_CLIENT)
            > 0) {
             fprintf(stderr,
                     "--message may resolve "

--- a/src/tcpkali_connection.h
+++ b/src/tcpkali_connection.h
@@ -23,6 +23,8 @@ struct connection {
     off_t write_offset;
     struct transport_data_spec data;
     non_atomic_traffic_stats traffic_ongoing;  /* Connection-local numbers */
+    size_t avg_message_size;
+    size_t bytes_leftovers;
     non_atomic_traffic_stats traffic_reported; /* Reported to worker */
     float channel_eol_point; /* End of life time, since epoch */
     struct pacefier send_pace;

--- a/src/tcpkali_connection.h
+++ b/src/tcpkali_connection.h
@@ -31,6 +31,7 @@ struct connection {
     struct pacefier recv_pace;
     bandwidth_limit_t send_limit;
     bandwidth_limit_t recv_limit;
+    struct message_collection message_collection;
     enum {
         CW_READ_INTEREST = 0x01,
         CW_READ_BLOCKED = 0x10,

--- a/src/tcpkali_engine.c
+++ b/src/tcpkali_engine.c
@@ -2134,7 +2134,7 @@ latency_record_outgoing_ts(TK_P_ struct connection *conn, const void *new_positi
                 conn->traffic_ongoing.msgs_sent++;
             }
         } else {
-                conn->traffic_ongoing.msgs_sent++;
+            conn->traffic_ongoing.msgs_sent += wrote / conn->data.single_message_size;
         }
         return;
     }

--- a/src/tcpkali_expr.c
+++ b/src/tcpkali_expr.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <assert.h>
+#include <math.h>
 
 #include "tcpkali_transport.h"
 #include "tcpkali_websocket.h"
@@ -50,33 +51,36 @@ void *yyrestart(FILE *);
 
 
 void
-free_expression(tk_expr_t *expr) {
+free_expression(tk_expr_t *expr, int delete_data) {
     if(expr) {
         switch(expr->type) {
         case EXPR_DATA:
-            free((void *)expr->u.data.data);
+            if (delete_data) free((void *)expr->u.data.data);
             break;
         case EXPR_RAW:
-            free_expression((void *)expr->u.raw.expr);
+            free_expression((void *)expr->u.raw.expr, delete_data);
             break;
         case EXPR_WS_FRAME:
-            free((void *)expr->u.ws_frame.data);
+            if (delete_data) free((void *)expr->u.ws_frame.data);
             break;
         case EXPR_MODULO:
-            free_expression((void *)expr->u.modulo.expr);
+            free_expression((void *)expr->u.modulo.expr, delete_data);
             break;
         case EXPR_CONCAT:
-            free_expression(expr->u.concat.expr[0]);
-            free_expression(expr->u.concat.expr[1]);
+            free_expression(expr->u.concat.expr[0], delete_data);
+            free_expression(expr->u.concat.expr[1], delete_data);
             break;
         case EXPR_CONNECTION_PTR:
         case EXPR_CONNECTION_UID:
         case EXPR_MESSAGE_MARKER:
             break;
-        case EXPR_REGEX:
-            tregex_free(expr->u.regex.re);
+        case EXPR_REGEX:{
+            if (delete_data) tregex_free(expr->u.regex.re);
             break;
+        };
         }
+        if (expr->res_buf) free((void *)expr->res_buf);
+        free((void *) expr);
     }
 }
 
@@ -102,13 +106,13 @@ parse_expression(tk_expr_t **expr_p, const char *buf, size_t size, int debug) {
         if(expr_p)
             *expr_p = expr;
         else
-            free_expression(expr);
+            free_expression(expr, 1);
         return 0;
     } else {
         char tmp[PRINTABLE_DATA_SUGGESTED_BUFFER_SIZE(size)];
         DEBUG("Failed to parse \"%s\"\n",
               printable_data(tmp, sizeof(tmp), buf, size, 1));
-        free_expression(expr);
+        free_expression(expr, 1);
         return -1;
     }
 }
@@ -125,16 +129,27 @@ eval_expression(char **buf_p, size_t size, tk_expr_t *expr, expr_callback_f cb,
     } else {
         buf = *buf_p;
     }
+    if (expr->dynamic_scope == DS_PER_CONNECTION && expr->res_buf){
+        /* Not first eval of "per connection" expr, just get res from a buffer */
+        memcpy(buf, expr->res_buf, expr->res_size);
+        return expr->res_size;
+    }
+
+    size_t res_size = -1;
 
     switch(expr->type) {
-    case EXPR_DATA:
+    case EXPR_DATA: {
         if(size < expr->u.data.size) return -1;
         memcpy(buf, expr->u.data.data, expr->u.data.size);
-        return expr->u.data.size;
-    case EXPR_RAW:
-        return eval_expression(buf_p, size, expr->u.raw.expr, cb, key, value,
+        res_size = expr->u.data.size;
+        break;
+    }
+    case EXPR_RAW: {
+        res_size = eval_expression(buf_p, size, expr->u.raw.expr, cb, key, value,
                                client_mode, rng);
-    case EXPR_WS_FRAME:
+        break;
+    }
+    case EXPR_WS_FRAME: {
         if(size < expr->estimate_size) {
             return -1;
         } else {
@@ -145,8 +160,10 @@ eval_expression(char **buf_p, size_t size, tk_expr_t *expr, expr_callback_f cb,
                 expr->u.ws_frame.fin, expr->u.ws_frame.size);
             memcpy(buf + hdr_size, expr->u.ws_frame.data,
                    expr->u.ws_frame.size);
-            return (hdr_size + expr->u.ws_frame.size);
+            res_size = (hdr_size + expr->u.ws_frame.size);
+            break;
         }
+    }
     case EXPR_MODULO: {
         long v = 0;
         (void)eval_expression(&buf, size, expr->u.modulo.expr, cb, key, &v,
@@ -155,8 +172,12 @@ eval_expression(char **buf_p, size_t size, tk_expr_t *expr, expr_callback_f cb,
         ssize_t s = snprintf(buf, size, "%ld", v);
         if(s < 0 || s > (ssize_t)size) return -1;
         if(value) *value = v;
-        return s;
-    } break;
+        if(expr->u.modulo.expr->dynamic_scope == DS_PER_CONNECTION) {
+            expr->dynamic_scope = DS_PER_CONNECTION;
+        }
+        res_size = s;
+        break;
+    }
     case EXPR_CONCAT: {
         if((expr->u.concat.expr[0]->estimate_size
             + expr->u.concat.expr[1]->estimate_size)
@@ -170,17 +191,138 @@ eval_expression(char **buf_p, size_t size, tk_expr_t *expr, expr_callback_f cb,
             eval_expression(&buf2, size - size1, expr->u.concat.expr[1], cb,
                             key, value, client_mode, rng);
         if(size1 < 0) return -1;
-        return size1 + size2;
+        res_size = size1 + size2;
+        break;
     }
-    case EXPR_CONNECTION_PTR:
-    case EXPR_CONNECTION_UID:
-    case EXPR_MESSAGE_MARKER:
-        return cb(buf, size, expr, key, value);
-    case EXPR_REGEX:
-        return tregex_eval_rng(expr->u.regex.re, buf, size, rng);
+    case EXPR_CONNECTION_PTR: {
+        res_size = cb(buf, size, expr, key, value);
+        break;
+    }
+    case EXPR_CONNECTION_UID: {
+        res_size = cb(buf, size, expr, key, value);
+        break;
+    }
+    case EXPR_MESSAGE_MARKER: {
+        res_size = cb(buf, size, expr, key, value);
+        break;
+    }
+    case EXPR_REGEX: {
+        res_size = tregex_eval_rng(expr->u.regex.re, buf, size, rng);
+    }
     }
 
-    return -1;
+    /* First eval of "per connection" expr, save results to a buffer */
+    if (expr->dynamic_scope == DS_PER_CONNECTION && res_size > 0){
+        expr->res_buf = malloc(res_size);
+        memcpy(expr->res_buf, buf, res_size);
+        expr->res_size = res_size;
+    }
+
+    return res_size;
+}
+
+tk_expr_t *
+replicate_expression(tk_expr_t *expr) {
+    if (!expr) return NULL;
+    switch(expr->type) {
+    case EXPR_DATA: {
+        tk_expr_t *new_expr = calloc(1, sizeof(tk_expr_t));
+        new_expr->type = EXPR_DATA;
+        new_expr->u.data.data = expr->u.data.data;
+        new_expr->u.data.size = expr->u.data.size;
+        new_expr->estimate_size = expr->estimate_size;
+        new_expr->dynamic_scope = expr->dynamic_scope;
+        new_expr->res_buf = NULL;
+        new_expr->res_size = 0;
+        return new_expr;
+    };
+    case EXPR_WS_FRAME: {
+        tk_expr_t *new_expr = calloc(1, sizeof(tk_expr_t));
+        new_expr->type = EXPR_WS_FRAME;
+        new_expr->u.ws_frame.data = expr->u.ws_frame.data;
+        new_expr->u.ws_frame.size = expr->u.ws_frame.size;
+        new_expr->u.ws_frame.opcode = expr->u.ws_frame.opcode;
+        new_expr->u.ws_frame.rsvs = expr->u.ws_frame.rsvs;
+        new_expr->u.ws_frame.fin = expr->u.ws_frame.fin;
+        new_expr->estimate_size = expr->estimate_size;
+        new_expr->dynamic_scope = expr->dynamic_scope;
+        new_expr->res_buf = NULL;
+        new_expr->res_size = 0;
+        return new_expr;
+    };
+    case EXPR_MESSAGE_MARKER: {
+        tk_expr_t *new_expr = calloc(1, sizeof(tk_expr_t));
+        new_expr->type = EXPR_MESSAGE_MARKER;
+        new_expr->estimate_size = expr->estimate_size;
+        new_expr->dynamic_scope = expr->dynamic_scope;
+        new_expr->res_buf = NULL;
+        new_expr->res_size = 0;
+        return new_expr;
+    };
+    case EXPR_RAW: {
+        tk_expr_t *new_expr = calloc(1, sizeof(tk_expr_t));
+        new_expr->type = EXPR_RAW;
+        new_expr->u.raw.expr = replicate_expression(expr->u.raw.expr);
+        new_expr->estimate_size = expr->estimate_size;
+        new_expr->dynamic_scope = expr->dynamic_scope;
+        new_expr->res_buf = NULL;
+        new_expr->res_size = 0;
+        return new_expr;
+    };
+    case EXPR_MODULO: {
+        tk_expr_t *new_expr = calloc(1, sizeof(tk_expr_t));
+        new_expr->type = EXPR_MODULO;
+        new_expr->u.modulo.expr = replicate_expression(expr->u.modulo.expr);;
+        new_expr->u.modulo.modulo_value = expr->u.modulo.modulo_value;
+        new_expr->estimate_size = expr->estimate_size;
+        new_expr->dynamic_scope = expr->dynamic_scope;
+        new_expr->res_buf = NULL;
+        new_expr->res_size = 0;
+        return new_expr;
+    };
+    case EXPR_CONCAT: {
+        tk_expr_t *new_expr = calloc(1, sizeof(tk_expr_t));
+        new_expr->type = EXPR_CONCAT;
+        new_expr->u.concat.expr[0] = replicate_expression(expr->u.concat.expr[0]);
+        new_expr->u.concat.expr[1] = replicate_expression(expr->u.concat.expr[1]);
+        new_expr->estimate_size = expr->estimate_size;
+        new_expr->dynamic_scope = expr->dynamic_scope;
+        new_expr->res_buf = NULL;
+        new_expr->res_size = 0;
+        return new_expr;
+    };
+    case EXPR_CONNECTION_PTR: {
+        tk_expr_t *new_expr = calloc(1, sizeof(tk_expr_t));
+        new_expr->type = EXPR_CONNECTION_PTR;
+        new_expr->estimate_size = expr->estimate_size;
+        new_expr->dynamic_scope = expr->dynamic_scope;
+        new_expr->res_buf = NULL;
+        new_expr->res_size = 0;
+        return new_expr;
+    };
+    case EXPR_CONNECTION_UID:{
+        tk_expr_t *new_expr = calloc(1, sizeof(tk_expr_t));
+        new_expr->type = EXPR_CONNECTION_UID;
+        new_expr->estimate_size = expr->estimate_size;
+        new_expr->dynamic_scope = expr->dynamic_scope;
+        new_expr->res_buf = NULL;
+        new_expr->res_size = 0;
+        return new_expr;
+    };
+    case EXPR_REGEX: {
+        tk_expr_t *new_expr = calloc(1, sizeof(tk_expr_t));
+        new_expr->type = EXPR_REGEX;
+        new_expr->u.regex.re = expr->u.regex.re;
+        new_expr->estimate_size = expr->estimate_size;
+        new_expr->dynamic_scope = expr->dynamic_scope;
+        new_expr->res_buf = NULL;
+        new_expr->res_size = 0;
+        return new_expr;
+    };
+
+    }
+
+    return NULL;
 }
 
 tk_expr_t *
@@ -191,7 +333,6 @@ concat_expressions(tk_expr_t *expr1, tk_expr_t *expr2) {
         expr->u.concat.expr[0] = expr1;
         expr->u.concat.expr[1] = expr2;
         expr->estimate_size = expr1->estimate_size + expr2->estimate_size;
-        expr->avg_size = expr1->avg_size + expr2->avg_size;
         expr->dynamic_scope = expr1->dynamic_scope > expr2->dynamic_scope
                                   ? expr1->dynamic_scope
                                   : expr2->dynamic_scope;
@@ -241,7 +382,7 @@ expression_split_by_websocket_frame(tk_expr_t *expr) {
         }
         expr->u.concat.expr[0] = NULL;
         expr->u.concat.expr[1] = NULL;
-        free_expression(expr);
+        free_expression(expr, 1);
         expr = NULL;
         if(result0.esw_websocket_frame) {
             result0.esw_remainder = concat_expressions(
@@ -287,7 +428,6 @@ unescape_expression(tk_expr_t *expr) {
     case EXPR_DATA:
         unescape_data((char *)expr->u.data.data, &expr->u.data.size);
         expr->estimate_size = expr->u.data.size;
-        expr->avg_size = expr->u.data.size;
         return;
     case EXPR_RAW:
         unescape_expression(expr->u.raw.expr);
@@ -297,10 +437,6 @@ unescape_expression(tk_expr_t *expr) {
         unescape_expression(expr->u.concat.expr[1]);
         expr->estimate_size = expr->u.concat.expr[0]->estimate_size
                               + expr->u.concat.expr[1]->estimate_size;
-        expr->avg_size = expr->u.concat.expr[0]->avg_size
-                              + expr->u.concat.expr[1]->avg_size;
-
-
         return;
     case EXPR_MODULO:
     case EXPR_CONNECTION_PTR:
@@ -317,23 +453,48 @@ unescape_expression(tk_expr_t *expr) {
     }
 }
 
+float avg_digit_num(long modulo) {
+    long s = labs(modulo);
+    long num = s;
+    long sum = 1;
+    s--;
+    long n = 9;
+    long d = 1;
+    while(1) {
+        if (s < n) {
+            sum += s*d;
+            return (float)sum / num;
+        }
+        sum += n*d;
+        s -= n;
+        n *= 10;
+        d++;
+    }
+}
+
 size_t average_size(tk_expr_t *expr) {
+    if (expr->res_buf) {
+        return expr->res_size;
+    }
+
     switch(expr->type) {
     case EXPR_CONCAT: {
         size_t avg_size = average_size(expr->u.concat.expr[0])
                         + average_size(expr->u.concat.expr[1]);
         return avg_size;
     }
-    case EXPR_REGEX:
+    case EXPR_REGEX: {
         return tregex_avg_size(expr->u.regex.re);
+    }
+    case EXPR_MODULO: {
+        return round(avg_digit_num(expr->u.modulo.modulo_value));
+    }
     case EXPR_DATA:
     case EXPR_RAW:
-    case EXPR_MODULO:
     case EXPR_CONNECTION_PTR:
     case EXPR_CONNECTION_UID:
     case EXPR_MESSAGE_MARKER:
-    case EXPR_WS_FRAME: {
+    case EXPR_WS_FRAME:
         return expr->estimate_size;
-    }
     }
 }

--- a/src/tcpkali_expr.h
+++ b/src/tcpkali_expr.h
@@ -70,6 +70,7 @@ typedef struct tk_expr {
         } regex;
     } u;
     size_t estimate_size;
+    size_t avg_size;
     enum tk_expr_dynamic_scope {
         DS_GLOBAL_FIXED,   /* All connection share data */
         DS_PER_CONNECTION, /* Each connection has its own */
@@ -132,5 +133,12 @@ struct esw_result expression_split_by_websocket_frame(tk_expr_t *expr);
  * Recursively go over all of the parts of the expression and unescape them.
  */
 void unescape_expression(tk_expr_t *expr);
+
+/*
+ * Recursively go over all of the parts of the expression and
+ * callculate average msg size.
+ */
+
+size_t average_size(tk_expr_t *expr);
 
 #endif /* TCPKALI_EXPR_H */

--- a/src/tcpkali_expr_y.c
+++ b/src/tcpkali_expr_y.c
@@ -498,11 +498,11 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,    75,    75,    83,    89,    92,    97,    98,   109,   120,
-     123,   127,   130,   140,   143,   158,   167,   180,   190,   202,
-     212,   220,   228,   238,   240,   245,   251,   253,   269,   279,
-     279,   282,   302,   305,   308,   313,   314,   319,   320,   321,
-     322,   323,   324,   327,   330,   333,   338,   339,   344,   347
+       0,    75,    75,    81,    87,    90,    95,    96,   107,   116,
+     119,   123,   126,   134,   137,   148,   155,   166,   174,   184,
+     192,   198,   204,   212,   214,   219,   225,   227,   243,   251,
+     251,   254,   274,   277,   280,   285,   286,   291,   292,   293,
+     294,   295,   296,   299,   302,   305,   310,   311,   316,   319
 };
 #endif
 
@@ -1336,42 +1336,40 @@ yyreduce:
 #line 75 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         expr->type = EXPR_DATA;
         *(tk_expr_t **)param = expr;
         return 0;
     }
-#line 1346 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1344 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 3:
-#line 83 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 81 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         *(tk_expr_t **)param = (yyvsp[-1].tv_expr);
         return 0;
     }
-#line 1355 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1353 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 4:
-#line 89 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 87 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[0].tv_expr);
     }
-#line 1363 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1361 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 5:
-#line 92 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 90 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = concat_expressions((yyvsp[-1].tv_expr), (yyvsp[0].tv_expr));
     }
-#line 1371 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1369 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 7:
-#line 98 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 96 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         size_t len = (((yyvsp[-1].tv_string)).len + ((yyvsp[0].tv_string)).len);
         char *p = malloc(len + 1);
@@ -1381,11 +1379,11 @@ yyreduce:
         (yyval.tv_string).buf = p;
         (yyval.tv_string).len = len;
     }
-#line 1385 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1383 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 8:
-#line 109 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 107 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         /* If there's nothing to parse, don't return anything */
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
@@ -1393,88 +1391,78 @@ yyreduce:
         expr->u.data.data = ((yyvsp[0].tv_string)).buf;
         expr->u.data.size = ((yyvsp[0].tv_string)).len;
         expr->estimate_size = ((yyvsp[0].tv_string)).len;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         (yyval.tv_expr) = expr;
     }
-#line 1401 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1397 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 9:
-#line 120 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 116 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
     }
-#line 1409 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1405 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 10:
-#line 123 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 119 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
     }
-#line 1417 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1413 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 12:
-#line 130 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 126 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {    /* \{<filename.txt>} */
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_DATA;
         expr->u.data.data = ((yyvsp[0].tv_string)).buf;
         expr->u.data.size = ((yyvsp[0].tv_string)).len;
         expr->estimate_size = ((yyvsp[0].tv_string)).len;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         (yyval.tv_expr) = expr;
     }
-#line 1432 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1426 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 13:
-#line 140 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 134 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[0].tv_expr);
     }
-#line 1440 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1434 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 14:
-#line 143 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 137 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_DATA;
         expr->u.data.data = ((yyvsp[0].tv_string)).buf;
         expr->u.data.size = ((yyvsp[0].tv_string)).len;
         expr->estimate_size = ((yyvsp[0].tv_string)).len;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         (yyval.tv_expr) = calloc(1, sizeof(tk_expr_t));
         (yyval.tv_expr)->type = EXPR_RAW;
         (yyval.tv_expr)->u.raw.expr = expr;
         (yyval.tv_expr)->estimate_size = expr->estimate_size;
-        (yyval.tv_expr)->res_buf = NULL;
-        (yyval.tv_expr)->res_size = 0;
     }
-#line 1460 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1450 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 15:
-#line 158 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 148 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(tk_expr_t));
         (yyval.tv_expr)->type = EXPR_RAW;
         (yyval.tv_expr)->u.raw.expr = (yyvsp[-1].tv_expr);
         (yyval.tv_expr)->estimate_size = (yyvsp[-1].tv_expr)->estimate_size;
         (yyval.tv_expr)->dynamic_scope = (yyvsp[-1].tv_expr)->dynamic_scope;
-        (yyval.tv_expr)->res_buf = NULL;
-        (yyval.tv_expr)->res_size = 0;
     }
-#line 1474 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1462 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 16:
-#line 167 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 155 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_DATA;
@@ -1483,118 +1471,104 @@ yyreduce:
         expr->u.data.data = data;
         expr->u.data.size = tregex_eval((yyvsp[0].tv_regex), data, tregex_max_size((yyvsp[0].tv_regex))+ 1);
         expr->estimate_size = expr->u.data.size;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         tregex_free((yyvsp[0].tv_regex));
         (yyval.tv_expr) = expr;
     }
-#line 1492 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1478 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 17:
-#line 180 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 166 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_REGEX;
         expr->u.regex.re = (yyvsp[0].tv_regex);
         expr->estimate_size = tregex_max_size((yyvsp[0].tv_regex));
         expr->dynamic_scope = DS_PER_CONNECTION;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         (yyval.tv_expr) = expr;
     }
-#line 1507 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1491 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 18:
-#line 190 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 174 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_REGEX;
         expr->u.regex.re = (yyvsp[0].tv_regex);
         expr->estimate_size = tregex_max_size((yyvsp[0].tv_regex));
         expr->dynamic_scope = DS_PER_MESSAGE;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         (yyval.tv_expr) = expr;
     }
-#line 1522 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1504 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 19:
-#line 202 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 184 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_MODULO;
         (yyval.tv_expr)->u.modulo.expr = (yyvsp[-2].tv_expr);
         (yyval.tv_expr)->u.modulo.modulo_value = (yyvsp[0].tv_long);
         (yyval.tv_expr)->estimate_size = (yyvsp[-2].tv_expr)->estimate_size;
-        (yyval.tv_expr)->res_buf = NULL;
-        (yyval.tv_expr)->res_size = 0;
         (yyval.tv_expr)->dynamic_scope = (yyvsp[-2].tv_expr)->dynamic_scope;
     }
-#line 1537 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1517 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 20:
-#line 212 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 192 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_CONNECTION_PTR;
         (yyval.tv_expr)->estimate_size = sizeof("100000000000000");
-        (yyval.tv_expr)->res_buf = NULL;
-        (yyval.tv_expr)->res_size = 0;
         (yyval.tv_expr)->dynamic_scope = DS_PER_CONNECTION;
     }
-#line 1550 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1528 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 21:
-#line 220 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 198 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_CONNECTION_UID;
         (yyval.tv_expr)->estimate_size = sizeof("100000000000000");
-        (yyval.tv_expr)->res_buf = NULL;
-        (yyval.tv_expr)->res_size = 0;
         (yyval.tv_expr)->dynamic_scope = DS_PER_CONNECTION;
     }
-#line 1563 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1539 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 22:
-#line 228 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 204 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_MESSAGE_MARKER;
         (yyval.tv_expr)->estimate_size = sizeof("1000000000000" "1000000000000000" "!") - 1;
-        (yyval.tv_expr)->res_buf = NULL;
-        (yyval.tv_expr)->res_size = 0;
         (yyval.tv_expr)->dynamic_scope = DS_PER_MESSAGE;
     }
-#line 1576 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1550 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 24:
-#line 240 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 214 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
         (yyval.tv_expr)->u.ws_frame.fin = 0; /* Expect continuation. */
     }
-#line 1585 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1559 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 25:
-#line 245 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 219 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
         (yyval.tv_expr)->u.ws_frame.rsvs |= (yyvsp[0].tv_long);
     }
-#line 1594 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1568 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 27:
-#line 253 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 227 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
         /* Combine old data with new data. */
@@ -1609,25 +1583,23 @@ yyreduce:
         (yyval.tv_expr)->u.ws_frame.size = total_size;
         (yyval.tv_expr)->estimate_size += ((yyvsp[0].tv_string)).len;
     }
-#line 1613 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1587 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 28:
-#line 269 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 243 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_WS_FRAME;
         (yyval.tv_expr)->u.ws_frame.opcode = (yyvsp[0].tv_opcode);
         (yyval.tv_expr)->u.ws_frame.fin = 1; /* Complete frame */
         (yyval.tv_expr)->estimate_size = WEBSOCKET_MAX_FRAME_HDR_SIZE;
-        (yyval.tv_expr)->res_buf = NULL;
-        (yyval.tv_expr)->res_size = 0;
     }
-#line 1627 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1599 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 31:
-#line 282 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 254 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         const char *name = (yyvsp[-1].tv_string).buf;
         FILE *fp = fopen(name, "r");
@@ -1646,113 +1618,113 @@ yyreduce:
         fclose(fp);
         (yyval.tv_string).buf[(yyval.tv_string).len] = '\0';
     }
-#line 1650 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1622 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 33:
-#line 305 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 277 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_alternative((yyvsp[0].tv_regex));
     }
-#line 1658 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1630 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 34:
-#line 308 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 280 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_alternative_add((yyvsp[-2].tv_regex), (yyvsp[0].tv_regex));
     }
-#line 1666 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1638 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 36:
-#line 314 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 286 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_join((yyvsp[-1].tv_regex), (yyvsp[0].tv_regex));
     }
-#line 1674 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1646 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 38:
-#line 320 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 292 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-1].tv_regex), 0, 1); }
-#line 1680 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1652 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 39:
-#line 321 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 293 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-1].tv_regex), 1, 16); }
-#line 1686 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1658 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 40:
-#line 322 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 294 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-1].tv_regex), 0, 16); }
-#line 1692 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1664 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 41:
-#line 323 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 295 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-3].tv_regex), (yyvsp[-1].tv_long), (yyvsp[-1].tv_long)); }
-#line 1698 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1670 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 42:
-#line 324 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 296 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-5].tv_regex), (yyvsp[-3].tv_long), (yyvsp[-1].tv_long)); }
-#line 1704 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1676 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 43:
-#line 327 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 299 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_string((yyvsp[0].tv_string).buf, (yyvsp[0].tv_string).len);
     }
-#line 1712 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1684 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 44:
-#line 330 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 302 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = (yyvsp[-1].tv_regex);
     }
-#line 1720 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1692 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 45:
-#line 333 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 305 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = (yyvsp[-1].tv_regex);
     }
-#line 1728 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1700 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 47:
-#line 339 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 311 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_union_ranges((yyvsp[-1].tv_regex), (yyvsp[0].tv_regex));
     }
-#line 1736 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1708 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 48:
-#line 344 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 316 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_range_from_string((yyvsp[0].tv_string).buf, (yyvsp[0].tv_string).len);
     }
-#line 1744 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1716 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 49:
-#line 347 "tcpkali_expr_y.y" /* yacc.c:1661  */
+#line 319 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_range((yyvsp[0].tv_class_range).from, (yyvsp[0].tv_class_range).to);
     }
-#line 1752 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1724 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
 
-#line 1756 "tcpkali_expr_y.c" /* yacc.c:1661  */
+#line 1728 "tcpkali_expr_y.c" /* yacc.c:1661  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1980,7 +1952,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 351 "tcpkali_expr_y.y" /* yacc.c:1906  */
+#line 323 "tcpkali_expr_y.y" /* yacc.c:1906  */
 
 
 int

--- a/src/tcpkali_expr_y.c
+++ b/src/tcpkali_expr_y.c
@@ -1541,7 +1541,7 @@ yyreduce:
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_MESSAGE_MARKER;
-        (yyval.tv_expr)->estimate_size = sizeof("100000000000000" "1000000000000000" "!");
+        (yyval.tv_expr)->estimate_size = sizeof("1000000000000" "1000000000000000" "!") - 1;
     }
 #line 1547 "tcpkali_expr_y.c" /* yacc.c:1646  */
     break;

--- a/src/tcpkali_expr_y.c
+++ b/src/tcpkali_expr_y.c
@@ -498,11 +498,11 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,    75,    75,    81,    87,    90,    95,    96,   107,   116,
-     119,   123,   126,   134,   138,   149,   156,   167,   175,   185,
-     192,   197,   202,   209,   211,   216,   222,   224,   240,   248,
-     248,   251,   271,   274,   277,   282,   283,   288,   289,   290,
-     291,   292,   293,   296,   299,   302,   307,   308,   313,   316
+       0,    75,    75,    83,    89,    92,    97,    98,   109,   120,
+     123,   127,   130,   140,   143,   158,   167,   180,   190,   202,
+     212,   220,   228,   238,   240,   245,   251,   253,   269,   279,
+     279,   282,   302,   305,   308,   313,   314,   319,   320,   321,
+     322,   323,   324,   327,   330,   333,   338,   339,   344,   347
 };
 #endif
 
@@ -1333,43 +1333,45 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 75 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 75 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         expr->type = EXPR_DATA;
         *(tk_expr_t **)param = expr;
         return 0;
     }
-#line 1344 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1346 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 3:
-#line 81 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 83 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         *(tk_expr_t **)param = (yyvsp[-1].tv_expr);
         return 0;
     }
-#line 1353 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1355 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 4:
-#line 87 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 89 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[0].tv_expr);
     }
-#line 1361 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1363 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 5:
-#line 90 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 92 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = concat_expressions((yyvsp[-1].tv_expr), (yyvsp[0].tv_expr));
     }
-#line 1369 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1371 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 7:
-#line 96 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 98 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         size_t len = (((yyvsp[-1].tv_string)).len + ((yyvsp[0].tv_string)).len);
         char *p = malloc(len + 1);
@@ -1379,11 +1381,11 @@ yyreduce:
         (yyval.tv_string).buf = p;
         (yyval.tv_string).len = len;
     }
-#line 1383 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1385 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 8:
-#line 107 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 109 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         /* If there's nothing to parse, don't return anything */
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
@@ -1391,79 +1393,88 @@ yyreduce:
         expr->u.data.data = ((yyvsp[0].tv_string)).buf;
         expr->u.data.size = ((yyvsp[0].tv_string)).len;
         expr->estimate_size = ((yyvsp[0].tv_string)).len;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         (yyval.tv_expr) = expr;
     }
-#line 1397 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1401 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 9:
-#line 116 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 120 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
     }
-#line 1405 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1409 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 10:
-#line 119 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 123 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
     }
-#line 1413 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1417 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 12:
-#line 126 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 130 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {    /* \{<filename.txt>} */
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_DATA;
         expr->u.data.data = ((yyvsp[0].tv_string)).buf;
         expr->u.data.size = ((yyvsp[0].tv_string)).len;
         expr->estimate_size = ((yyvsp[0].tv_string)).len;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         (yyval.tv_expr) = expr;
     }
-#line 1426 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1432 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 13:
-#line 134 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 140 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[0].tv_expr);
-        (yyval.tv_expr)->dynamic_scope = DS_PER_CONNECTION;
     }
-#line 1435 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1440 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 14:
-#line 138 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 143 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_DATA;
         expr->u.data.data = ((yyvsp[0].tv_string)).buf;
         expr->u.data.size = ((yyvsp[0].tv_string)).len;
         expr->estimate_size = ((yyvsp[0].tv_string)).len;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         (yyval.tv_expr) = calloc(1, sizeof(tk_expr_t));
         (yyval.tv_expr)->type = EXPR_RAW;
         (yyval.tv_expr)->u.raw.expr = expr;
         (yyval.tv_expr)->estimate_size = expr->estimate_size;
+        (yyval.tv_expr)->res_buf = NULL;
+        (yyval.tv_expr)->res_size = 0;
     }
-#line 1451 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1460 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 15:
-#line 149 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 158 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(tk_expr_t));
         (yyval.tv_expr)->type = EXPR_RAW;
         (yyval.tv_expr)->u.raw.expr = (yyvsp[-1].tv_expr);
         (yyval.tv_expr)->estimate_size = (yyvsp[-1].tv_expr)->estimate_size;
         (yyval.tv_expr)->dynamic_scope = (yyvsp[-1].tv_expr)->dynamic_scope;
+        (yyval.tv_expr)->res_buf = NULL;
+        (yyval.tv_expr)->res_size = 0;
     }
-#line 1463 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1474 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 16:
-#line 156 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 167 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_DATA;
@@ -1472,100 +1483,118 @@ yyreduce:
         expr->u.data.data = data;
         expr->u.data.size = tregex_eval((yyvsp[0].tv_regex), data, tregex_max_size((yyvsp[0].tv_regex))+ 1);
         expr->estimate_size = expr->u.data.size;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         tregex_free((yyvsp[0].tv_regex));
         (yyval.tv_expr) = expr;
     }
-#line 1479 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1492 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 17:
-#line 167 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 180 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_REGEX;
         expr->u.regex.re = (yyvsp[0].tv_regex);
         expr->estimate_size = tregex_max_size((yyvsp[0].tv_regex));
         expr->dynamic_scope = DS_PER_CONNECTION;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         (yyval.tv_expr) = expr;
     }
-#line 1492 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1507 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 18:
-#line 175 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 190 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
         expr->type = EXPR_REGEX;
         expr->u.regex.re = (yyvsp[0].tv_regex);
         expr->estimate_size = tregex_max_size((yyvsp[0].tv_regex));
         expr->dynamic_scope = DS_PER_MESSAGE;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         (yyval.tv_expr) = expr;
     }
-#line 1505 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1522 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 19:
-#line 185 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 202 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_MODULO;
         (yyval.tv_expr)->u.modulo.expr = (yyvsp[-2].tv_expr);
         (yyval.tv_expr)->u.modulo.modulo_value = (yyvsp[0].tv_long);
         (yyval.tv_expr)->estimate_size = (yyvsp[-2].tv_expr)->estimate_size;
+        (yyval.tv_expr)->res_buf = NULL;
+        (yyval.tv_expr)->res_size = 0;
+        (yyval.tv_expr)->dynamic_scope = (yyvsp[-2].tv_expr)->dynamic_scope;
     }
-#line 1517 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1537 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 20:
-#line 192 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 212 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_CONNECTION_PTR;
         (yyval.tv_expr)->estimate_size = sizeof("100000000000000");
+        (yyval.tv_expr)->res_buf = NULL;
+        (yyval.tv_expr)->res_size = 0;
+        (yyval.tv_expr)->dynamic_scope = DS_PER_CONNECTION;
     }
-#line 1527 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1550 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 21:
-#line 197 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 220 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_CONNECTION_UID;
         (yyval.tv_expr)->estimate_size = sizeof("100000000000000");
+        (yyval.tv_expr)->res_buf = NULL;
+        (yyval.tv_expr)->res_size = 0;
+        (yyval.tv_expr)->dynamic_scope = DS_PER_CONNECTION;
     }
-#line 1537 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1563 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 22:
-#line 202 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 228 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_MESSAGE_MARKER;
         (yyval.tv_expr)->estimate_size = sizeof("1000000000000" "1000000000000000" "!") - 1;
+        (yyval.tv_expr)->res_buf = NULL;
+        (yyval.tv_expr)->res_size = 0;
+        (yyval.tv_expr)->dynamic_scope = DS_PER_MESSAGE;
     }
-#line 1547 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1576 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 24:
-#line 211 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 240 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
         (yyval.tv_expr)->u.ws_frame.fin = 0; /* Expect continuation. */
     }
-#line 1556 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1585 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 25:
-#line 216 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 245 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
         (yyval.tv_expr)->u.ws_frame.rsvs |= (yyvsp[0].tv_long);
     }
-#line 1565 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1594 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 27:
-#line 224 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 253 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = (yyvsp[-1].tv_expr);
         /* Combine old data with new data. */
@@ -1580,23 +1609,25 @@ yyreduce:
         (yyval.tv_expr)->u.ws_frame.size = total_size;
         (yyval.tv_expr)->estimate_size += ((yyvsp[0].tv_string)).len;
     }
-#line 1584 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1613 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 28:
-#line 240 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 269 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_expr) = calloc(1, sizeof(*((yyval.tv_expr))));
         (yyval.tv_expr)->type = EXPR_WS_FRAME;
         (yyval.tv_expr)->u.ws_frame.opcode = (yyvsp[0].tv_opcode);
         (yyval.tv_expr)->u.ws_frame.fin = 1; /* Complete frame */
         (yyval.tv_expr)->estimate_size = WEBSOCKET_MAX_FRAME_HDR_SIZE;
+        (yyval.tv_expr)->res_buf = NULL;
+        (yyval.tv_expr)->res_size = 0;
     }
-#line 1596 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1627 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 31:
-#line 251 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 282 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         const char *name = (yyvsp[-1].tv_string).buf;
         FILE *fp = fopen(name, "r");
@@ -1615,113 +1646,113 @@ yyreduce:
         fclose(fp);
         (yyval.tv_string).buf[(yyval.tv_string).len] = '\0';
     }
-#line 1619 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1650 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 33:
-#line 274 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 305 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_alternative((yyvsp[0].tv_regex));
     }
-#line 1627 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1658 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 34:
-#line 277 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 308 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_alternative_add((yyvsp[-2].tv_regex), (yyvsp[0].tv_regex));
     }
-#line 1635 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1666 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 36:
-#line 283 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 314 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_join((yyvsp[-1].tv_regex), (yyvsp[0].tv_regex));
     }
-#line 1643 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1674 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 38:
-#line 289 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 320 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-1].tv_regex), 0, 1); }
-#line 1649 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1680 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 39:
-#line 290 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 321 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-1].tv_regex), 1, 16); }
-#line 1655 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1686 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 40:
-#line 291 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 322 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-1].tv_regex), 0, 16); }
-#line 1661 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1692 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 41:
-#line 292 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 323 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-3].tv_regex), (yyvsp[-1].tv_long), (yyvsp[-1].tv_long)); }
-#line 1667 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1698 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 42:
-#line 293 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 324 "tcpkali_expr_y.y" /* yacc.c:1661  */
     { (yyval.tv_regex) = tregex_repeat((yyvsp[-5].tv_regex), (yyvsp[-3].tv_long), (yyvsp[-1].tv_long)); }
-#line 1673 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1704 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 43:
-#line 296 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 327 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_string((yyvsp[0].tv_string).buf, (yyvsp[0].tv_string).len);
     }
-#line 1681 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1712 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 44:
-#line 299 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 330 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = (yyvsp[-1].tv_regex);
     }
-#line 1689 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1720 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 45:
-#line 302 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 333 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = (yyvsp[-1].tv_regex);
     }
-#line 1697 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1728 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 47:
-#line 308 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 339 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_union_ranges((yyvsp[-1].tv_regex), (yyvsp[0].tv_regex));
     }
-#line 1705 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1736 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 48:
-#line 313 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 344 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_range_from_string((yyvsp[0].tv_string).buf, (yyvsp[0].tv_string).len);
     }
-#line 1713 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1744 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
   case 49:
-#line 316 "tcpkali_expr_y.y" /* yacc.c:1646  */
+#line 347 "tcpkali_expr_y.y" /* yacc.c:1661  */
     {
         (yyval.tv_regex) = tregex_range((yyvsp[0].tv_class_range).from, (yyvsp[0].tv_class_range).to);
     }
-#line 1721 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1752 "tcpkali_expr_y.c" /* yacc.c:1661  */
     break;
 
 
-#line 1725 "tcpkali_expr_y.c" /* yacc.c:1646  */
+#line 1756 "tcpkali_expr_y.c" /* yacc.c:1661  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1949,7 +1980,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 320 "tcpkali_expr_y.y" /* yacc.c:1906  */
+#line 351 "tcpkali_expr_y.y" /* yacc.c:1906  */
 
 
 int

--- a/src/tcpkali_expr_y.h
+++ b/src/tcpkali_expr_y.h
@@ -92,7 +92,7 @@ extern int yydebug;
 
 union YYSTYPE
 {
-#line 21 "tcpkali_expr_y.y" /* yacc.c:1909  */
+#line 21 "tcpkali_expr_y.y" /* yacc.c:1915  */
 
     tk_expr_t   *tv_expr;
     tregex      *tv_regex;
@@ -112,7 +112,7 @@ union YYSTYPE
     enum ws_frame_opcode tv_opcode;
     char  tv_char;
 
-#line 116 "tcpkali_expr_y.h" /* yacc.c:1909  */
+#line 116 "tcpkali_expr_y.h" /* yacc.c:1915  */
 };
 
 typedef union YYSTYPE YYSTYPE;

--- a/src/tcpkali_expr_y.y
+++ b/src/tcpkali_expr_y.y
@@ -74,8 +74,6 @@ int yyerror(tk_expr_t **, const char *);
 Grammar:
     END {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         expr->type = EXPR_DATA;
         *(tk_expr_t **)param = expr;
         return 0;
@@ -113,8 +111,6 @@ ByteSequenceOrExpr:
         expr->u.data.data = ($1).buf;
         expr->u.data.size = ($1).len;
         expr->estimate_size = ($1).len;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         $$ = expr;
     }
     | '{' WSExpression '}' {
@@ -133,8 +129,6 @@ NonWSExpression:
         expr->u.data.data = ($1).buf;
         expr->u.data.size = ($1).len;
         expr->estimate_size = ($1).len;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         $$ = expr;
     }
     | NumericExpr {
@@ -146,14 +140,10 @@ NonWSExpression:
         expr->u.data.data = ($2).buf;
         expr->u.data.size = ($2).len;
         expr->estimate_size = ($2).len;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         $$ = calloc(1, sizeof(tk_expr_t));
         $$->type = EXPR_RAW;
         $$->u.raw.expr = expr;
         $$->estimate_size = expr->estimate_size;
-        $$->res_buf = NULL;
-        $$->res_size = 0;
     }
     | TOK_raw '{' NonWSExpression '}' {
         $$ = calloc(1, sizeof(tk_expr_t));
@@ -161,8 +151,6 @@ NonWSExpression:
         $$->u.raw.expr = $3;
         $$->estimate_size = $3->estimate_size;
         $$->dynamic_scope = $3->dynamic_scope;
-        $$->res_buf = NULL;
-        $$->res_size = 0;
     }
     | TOK_global '.' TOK_regex CompleteRegex {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
@@ -172,8 +160,6 @@ NonWSExpression:
         expr->u.data.data = data;
         expr->u.data.size = tregex_eval($4, data, tregex_max_size($4)+ 1);
         expr->estimate_size = expr->u.data.size;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         tregex_free($4);
         $$ = expr;
     }
@@ -183,8 +169,6 @@ NonWSExpression:
         expr->u.regex.re = $4;
         expr->estimate_size = tregex_max_size($4);
         expr->dynamic_scope = DS_PER_CONNECTION;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         $$ = expr;
     }
     | TOK_regex CompleteRegex {
@@ -193,8 +177,6 @@ NonWSExpression:
         expr->u.regex.re = $2;
         expr->estimate_size = tregex_max_size($2);
         expr->dynamic_scope = DS_PER_MESSAGE;
-        expr->res_buf = NULL;
-        expr->res_size = 0;
         $$ = expr;
     }
 
@@ -205,32 +187,24 @@ NumericExpr:
         $$->u.modulo.expr = $1;
         $$->u.modulo.modulo_value = $3;
         $$->estimate_size = $1->estimate_size;
-        $$->res_buf = NULL;
-        $$->res_size = 0;
         $$->dynamic_scope = $1->dynamic_scope;
     }
     | TOK_connection '.' TOK_ptr {
         $$ = calloc(1, sizeof(*($$)));
         $$->type = EXPR_CONNECTION_PTR;
         $$->estimate_size = sizeof("100000000000000");
-        $$->res_buf = NULL;
-        $$->res_size = 0;
         $$->dynamic_scope = DS_PER_CONNECTION;
     }
     | TOK_connection '.' TOK_uid {
         $$ = calloc(1, sizeof(*($$)));
         $$->type = EXPR_CONNECTION_UID;
         $$->estimate_size = sizeof("100000000000000");
-        $$->res_buf = NULL;
-        $$->res_size = 0;
         $$->dynamic_scope = DS_PER_CONNECTION;
     }
     | TOK_message '.' TOK_marker {
         $$ = calloc(1, sizeof(*($$)));
         $$->type = EXPR_MESSAGE_MARKER;
         $$->estimate_size = sizeof("1000000000000" "1000000000000000" "!") - 1;
-        $$->res_buf = NULL;
-        $$->res_size = 0;
         $$->dynamic_scope = DS_PER_MESSAGE;
     }
 
@@ -272,8 +246,6 @@ WSBasicFrame:
         $$->u.ws_frame.opcode = $3;
         $$->u.ws_frame.fin = 1; /* Complete frame */
         $$->estimate_size = WEBSOCKET_MAX_FRAME_HDR_SIZE;
-        $$->res_buf = NULL;
-        $$->res_size = 0;
     }
 
 FileOrQuoted: quoted_string | File

--- a/src/tcpkali_expr_y.y
+++ b/src/tcpkali_expr_y.y
@@ -202,7 +202,7 @@ NumericExpr:
     | TOK_message '.' TOK_marker {
         $$ = calloc(1, sizeof(*($$)));
         $$->type = EXPR_MESSAGE_MARKER;
-        $$->estimate_size = sizeof("100000000000000" "1000000000000000" "!");
+        $$->estimate_size = sizeof("1000000000000" "1000000000000000" "!") - 1;
     }
 
 WSFrameFinalized:

--- a/src/tcpkali_expr_y.y
+++ b/src/tcpkali_expr_y.y
@@ -74,6 +74,8 @@ int yyerror(tk_expr_t **, const char *);
 Grammar:
     END {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         expr->type = EXPR_DATA;
         *(tk_expr_t **)param = expr;
         return 0;
@@ -111,6 +113,8 @@ ByteSequenceOrExpr:
         expr->u.data.data = ($1).buf;
         expr->u.data.size = ($1).len;
         expr->estimate_size = ($1).len;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         $$ = expr;
     }
     | '{' WSExpression '}' {
@@ -129,6 +133,8 @@ NonWSExpression:
         expr->u.data.data = ($1).buf;
         expr->u.data.size = ($1).len;
         expr->estimate_size = ($1).len;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         $$ = expr;
     }
     | NumericExpr {
@@ -141,10 +147,14 @@ NonWSExpression:
         expr->u.data.data = ($2).buf;
         expr->u.data.size = ($2).len;
         expr->estimate_size = ($2).len;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         $$ = calloc(1, sizeof(tk_expr_t));
         $$->type = EXPR_RAW;
         $$->u.raw.expr = expr;
         $$->estimate_size = expr->estimate_size;
+        $$->res_buf = NULL;
+        $$->res_size = 0;
     }
     | TOK_raw '{' NonWSExpression '}' {
         $$ = calloc(1, sizeof(tk_expr_t));
@@ -152,6 +162,8 @@ NonWSExpression:
         $$->u.raw.expr = $3;
         $$->estimate_size = $3->estimate_size;
         $$->dynamic_scope = $3->dynamic_scope;
+        $$->res_buf = NULL;
+        $$->res_size = 0;
     }
     | TOK_global '.' TOK_regex CompleteRegex {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
@@ -161,6 +173,8 @@ NonWSExpression:
         expr->u.data.data = data;
         expr->u.data.size = tregex_eval($4, data, tregex_max_size($4)+ 1);
         expr->estimate_size = expr->u.data.size;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         tregex_free($4);
         $$ = expr;
     }
@@ -170,6 +184,8 @@ NonWSExpression:
         expr->u.regex.re = $4;
         expr->estimate_size = tregex_max_size($4);
         expr->dynamic_scope = DS_PER_CONNECTION;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         $$ = expr;
     }
     | TOK_regex CompleteRegex {
@@ -178,6 +194,8 @@ NonWSExpression:
         expr->u.regex.re = $2;
         expr->estimate_size = tregex_max_size($2);
         expr->dynamic_scope = DS_PER_MESSAGE;
+        expr->res_buf = NULL;
+        expr->res_size = 0;
         $$ = expr;
     }
 
@@ -188,21 +206,29 @@ NumericExpr:
         $$->u.modulo.expr = $1;
         $$->u.modulo.modulo_value = $3;
         $$->estimate_size = $1->estimate_size;
+        $$->res_buf = NULL;
+        $$->res_size = 0;
     }
     | TOK_connection '.' TOK_ptr {
         $$ = calloc(1, sizeof(*($$)));
         $$->type = EXPR_CONNECTION_PTR;
         $$->estimate_size = sizeof("100000000000000");
+        $$->res_buf = NULL;
+        $$->res_size = 0;
     }
     | TOK_connection '.' TOK_uid {
         $$ = calloc(1, sizeof(*($$)));
         $$->type = EXPR_CONNECTION_UID;
         $$->estimate_size = sizeof("100000000000000");
+        $$->res_buf = NULL;
+        $$->res_size = 0;
     }
     | TOK_message '.' TOK_marker {
         $$ = calloc(1, sizeof(*($$)));
         $$->type = EXPR_MESSAGE_MARKER;
         $$->estimate_size = sizeof("1000000000000" "1000000000000000" "!") - 1;
+        $$->res_buf = NULL;
+        $$->res_size = 0;
     }
 
 WSFrameFinalized:
@@ -243,6 +269,8 @@ WSBasicFrame:
         $$->u.ws_frame.opcode = $3;
         $$->u.ws_frame.fin = 1; /* Complete frame */
         $$->estimate_size = WEBSOCKET_MAX_FRAME_HDR_SIZE;
+        $$->res_buf = NULL;
+        $$->res_size = 0;
     }
 
 FileOrQuoted: quoted_string | File

--- a/src/tcpkali_expr_y.y
+++ b/src/tcpkali_expr_y.y
@@ -139,7 +139,6 @@ NonWSExpression:
     }
     | NumericExpr {
         $$ = $1;
-        $$->dynamic_scope = DS_PER_CONNECTION;
     }
     | TOK_raw FileOrQuoted {
         tk_expr_t *expr = calloc(1, sizeof(tk_expr_t));
@@ -208,6 +207,7 @@ NumericExpr:
         $$->estimate_size = $1->estimate_size;
         $$->res_buf = NULL;
         $$->res_size = 0;
+        $$->dynamic_scope = $1->dynamic_scope;
     }
     | TOK_connection '.' TOK_ptr {
         $$ = calloc(1, sizeof(*($$)));
@@ -215,6 +215,7 @@ NumericExpr:
         $$->estimate_size = sizeof("100000000000000");
         $$->res_buf = NULL;
         $$->res_size = 0;
+        $$->dynamic_scope = DS_PER_CONNECTION;
     }
     | TOK_connection '.' TOK_uid {
         $$ = calloc(1, sizeof(*($$)));
@@ -222,6 +223,7 @@ NumericExpr:
         $$->estimate_size = sizeof("100000000000000");
         $$->res_buf = NULL;
         $$->res_size = 0;
+        $$->dynamic_scope = DS_PER_CONNECTION;
     }
     | TOK_message '.' TOK_marker {
         $$ = calloc(1, sizeof(*($$)));
@@ -229,6 +231,7 @@ NumericExpr:
         $$->estimate_size = sizeof("1000000000000" "1000000000000000" "!") - 1;
         $$->res_buf = NULL;
         $$->res_size = 0;
+        $$->dynamic_scope = DS_PER_MESSAGE;
     }
 
 WSFrameFinalized:

--- a/src/tcpkali_regex.c
+++ b/src/tcpkali_regex.c
@@ -67,6 +67,7 @@ tregex_debug_print(tregex *re) {
         printf(")");
         break;
     case TRegexRepeat:
+        tregex_debug_print(re->repeat.what);
         if(re->repeat.minimum == 0 && re->repeat.range == 1) {
             printf("?");
         } else {

--- a/src/tcpkali_regex.c
+++ b/src/tcpkali_regex.c
@@ -16,6 +16,7 @@ struct tregex {
         TRegexRepeat
     } kind;
     size_t min_size;
+    size_t avg_size;
     size_t max_size;
     union {
         struct {
@@ -82,6 +83,7 @@ tregex_string(const char *str, ssize_t len) {
     tregex *re = calloc(1, sizeof(*re));
     re->kind = TRegexChars;
     re->min_size = len;
+    re->avg_size = len;
     re->max_size = len;
     re->chars.data = calloc(1, len + 1);
     assert(re->chars.data);
@@ -100,6 +102,7 @@ tregex_join(tregex *re, tregex *rhs) {
             re->sequence.pieces += rhs->sequence.pieces;
             rhs->sequence.pieces = 0;
             re->min_size += rhs->min_size;
+            re->avg_size += rhs->avg_size;
             re->max_size += rhs->max_size;
             return re;
         } else {
@@ -112,6 +115,7 @@ tregex_join(tregex *re, tregex *rhs) {
         if(re->sequence.pieces < TREGEX_ELEMENTS) {
             re->sequence.piece[re->sequence.pieces++] = rhs;
             re->min_size += rhs->min_size;
+            re->avg_size += rhs->avg_size;
             re->max_size += rhs->max_size;
             return re;
         } else {
@@ -136,6 +140,7 @@ tregex_range(unsigned char from, unsigned char to) {
     tregex *re = calloc(1, sizeof(*re));
     re->kind = TRegexClass;
     re->min_size = 1;
+    re->avg_size = 1;
     re->max_size = 1;
     for(unsigned i = from; i <= to; i++) {
         re->oneof.table[re->oneof.size++] = i;
@@ -149,6 +154,7 @@ tregex_range_from_string(const char *str, ssize_t len) {
     tregex *re = calloc(1, sizeof(*re));
     re->kind = TRegexClass;
     re->min_size = 1;
+    re->avg_size = 1;
     re->max_size = 1;
     uint8_t used[256];
     memset(used, 0, sizeof(used));
@@ -186,6 +192,7 @@ tregex_alternative(tregex *rhs) {
     tregex *re = calloc(1, sizeof(*re));
     re->kind = TRegexAlternative;
     re->min_size = rhs->min_size;
+    re->avg_size = rhs->avg_size;
     re->max_size = rhs->max_size;
     re->alternative.branch[0] = rhs;
     re->alternative.branches = 1;
@@ -203,6 +210,11 @@ tregex_alternative_add(tregex *re, tregex *rhs) {
     }
     if(re->min_size > rhs->min_size) re->min_size = rhs->min_size;
     if(re->max_size < rhs->max_size) re->max_size = rhs->max_size;
+    size_t size_sum = 0;
+    for (size_t i = 0; i < re->alternative.branches; i++) {
+        size_sum += re->alternative.branch[i]->avg_size;
+    }
+    re->avg_size = size_sum / re->alternative.branches;
     return re;
 }
 
@@ -219,6 +231,7 @@ tregex_repeat(tregex *what, unsigned start, unsigned stop) {
     re->repeat.minimum = start;
     re->repeat.range = 1 + stop - start;
     re->min_size = what->min_size * start;
+    re->avg_size = (what->avg_size * (stop + start)) / 2;
     re->max_size = what->max_size * stop;
     return re;
 }
@@ -303,6 +316,12 @@ size_t
 tregex_min_size(tregex *re) {
     assert(re);
     return re->min_size;
+}
+
+size_t
+tregex_avg_size(tregex *re) {
+    assert(re);
+    return re->avg_size;
 }
 
 size_t

--- a/src/tcpkali_regex.c
+++ b/src/tcpkali_regex.c
@@ -308,7 +308,7 @@ tregex_eval_rng(tregex *re, char *buf, size_t size, pcg32_random_t *rng) {
     }
 
     assert(buf <= bend);
-    if(bold > buf) *buf = '\0';
+    if(bold < buf) *buf = '\0';
 
     return (buf - bold);
 }

--- a/src/tcpkali_regex.h
+++ b/src/tcpkali_regex.h
@@ -54,6 +54,7 @@ tregex *tregex_alternative_add(tregex *base, tregex *rhs);
 tregex *tregex_repeat(tregex *, unsigned from, unsigned to);
 
 size_t tregex_min_size(tregex *);
+size_t tregex_avg_size(tregex *);
 size_t tregex_max_size(tregex *);
 
 /*

--- a/src/tcpkali_transport.h
+++ b/src/tcpkali_transport.h
@@ -117,7 +117,8 @@ size_t message_collection_estimate_size(struct message_collection *mc,
                                         enum mc_snippet_kind kind_and,
                                         enum mc_snippet_kind kind_equal,
                                         enum mc_snippet_estimate,
-                                        enum websocket_side ws_side);
+                                        enum websocket_side ws_side,
+                                        int ws_enable);
 
 /*
  * Our send buffer is pre-computed in advance and may be shared
@@ -168,5 +169,14 @@ struct transport_data_spec *transport_spec_from_message_collection(
  */
 void replicate_payload(struct transport_data_spec *data,
                        size_t target_payload_size);
+
+/*
+ * Replicate snippets (need to replicate expressions)
+ * it does not copy data
+ */
+void message_collection_replicate(struct message_collection *mc_from,
+                                  struct message_collection *mc_to);
+
+void message_collection_free(struct message_collection *mc);
 
 #endif /* TCPKALI_TRANSPORT_H */

--- a/src/tcpkali_transport.h
+++ b/src/tcpkali_transport.h
@@ -112,11 +112,12 @@ int message_collection_has(const struct message_collection *, enum tk_expr_type)
  * Estimate the size of the snippets of the specified kind (and mask).
  * Works on a finalized message collection.
  */
-enum mc_snippet_estimate { MCE_MINIMUM_SIZE, MCE_MAXIMUM_SIZE };
+enum mc_snippet_estimate { MCE_MINIMUM_SIZE, MCE_MAXIMUM_SIZE, MCE_AVERAGE_SIZE };
 size_t message_collection_estimate_size(struct message_collection *mc,
                                         enum mc_snippet_kind kind_and,
                                         enum mc_snippet_kind kind_equal,
-                                        enum mc_snippet_estimate);
+                                        enum mc_snippet_estimate,
+                                        enum websocket_side ws_side);
 
 /*
  * Our send buffer is pre-computed in advance and may be shared

--- a/test/check-tcpkali-operation.sh
+++ b/test/check-tcpkali-operation.sh
@@ -90,8 +90,8 @@ for size_k in 63 65 1000; do
 done
 rm_testfile
 
-check 24 "Packet rate estimate: (19|20)" ${TCPKALI} -m 'Foo\{message.marker}' -r10
-check 25 "Packet rate estimate: (19|20)" ${TCPKALI} --ws -m '\{message.marker}\{re [a-z]{1,300}}' -r10
+check 24 "Packet rate estimate: (9|10|11)" ${TCPKALI} -m 'Foo\{message.marker}' -r10
+check 25 "Packet rate estimate: (9|10|11)" ${TCPKALI} --ws -m '\{message.marker}\{re [a-z]{1,300}}' -r10
 
 check 26 "." ${TCPKALI} ./tcpkali -1 '\{message.marker}' -m '\{message.marker}'
 

--- a/test/check-tcpkali-operation.sh
+++ b/test/check-tcpkali-operation.sh
@@ -96,6 +96,6 @@ rm_testfile
 check 24 "Packet rate estimate: (9|10|11)" ${TCPKALI} -m 'Foo\{message.marker}' -r10
 check 25 "Packet rate estimate: (9|10|11)" ${TCPKALI} --ws -m '\{message.marker}\{re [a-z]{1,300}}' -r10
 
-check 26 "." ${TCPKALI} ./tcpkali -1 '\{message.marker}' -m '\{message.marker}'
+check 26 "." ${TCPKALI} -1 '\{message.marker}' -m '\{message.marker}'
 
 trap 'rm -f ${TMPFILE}' EXIT

--- a/test/check-tcpkali-operation.sh
+++ b/test/check-tcpkali-operation.sh
@@ -55,10 +55,10 @@ check 2 "." ${TCPKALI} -vv --connections=10 --duration=1 -m Z
 check 3 "." ${TCPKALI} -vv -c10 --message Z --message-rate=2
 check 4 "." ${TCPKALI} -vv -c10 -m Z --channel-bandwidth-upstream=10kbps
 
-check 5 "Total data sent:[ ]+149 bytes"     ${TCPKALI} -vv --ws -w3
-check 6 "Total data received:[ ]+278 bytes" ${TCPKALI} -vv --ws -w3
-check 7 "Total data sent:[ ]+158 bytes"     ${TCPKALI} -vv --ws --first-message ABC -w3
-check 8 "Total data received:[ ]+287 bytes" ${TCPKALI} -vv --ws -1 ABC -w3
+check 5 "Total data sent:[ ]+149 bytes"     ${TCPKALI} -vv --ws -w2
+check 6 "Total data received:[ ]+278 bytes" ${TCPKALI} -vv --ws -w2
+check 7 "Total data sent:[ ]+158 bytes"     ${TCPKALI} -vv --ws --first-message ABC -w2
+check 8 "Total data received:[ ]+287 bytes" ${TCPKALI} -vv --ws -1 ABC -w2
 
 check 9 "." ${TCPKALI} --ws --message ABC
 check 10 "." ${TCPKALI} --ws --first-message ABC --message foo

--- a/test/check-tcpkali-operation.sh
+++ b/test/check-tcpkali-operation.sh
@@ -15,7 +15,8 @@ fi
 
 TMPFILE=/tmp/check-tcpkali-output.$$
 rmtmp() {
-    local lines=$(wc -l ${TMPFILE} | awk '{print $1}')
+    local lines
+    lines=$(wc -l ${TMPFILE} | awk '{print $1}')
     if [ ${lines} -gt 150 ]; then
         echo "First 50 lines of tcpkali output (total ${lines}):"
         head -50 ${TMPFILE}
@@ -38,15 +39,17 @@ check() {
     local togrep="$2"
     shift 2
 
-    if [ -n "${use_test_no}" -a "${testno}" != "${use_test_no}" ]; then
+    if [ -n "${use_test_no}" ] && [ "${testno}" != "${use_test_no}" ]; then
         return
     fi
 
     PORT=$((PORT+1))
-    local rest_opts="-T1s -l127.1:${PORT} 127.1:${PORT}"
+    local rest_opts
+    rest_opts="-T1s -l127.1:${PORT} 127.1:${PORT}"
     echo "Test ${testno}.autoip: $* ${rest_opts}" | tee ${TMPFILE} >&2
     echo "Looking for \"$togrep\" in '$* ${rest_opts}'" >> ${TMPFILE}
-    local out=$("$@" ${rest_opts} 2>&1 | tee -a ${TMPFILE} | egrep -c "$togrep")
+    local out
+    out=$("$@" ${rest_opts} 2>&1 | tee -a ${TMPFILE} | grep -E -c "$togrep")
     [ $out -ne 0 ] || exit 1
 }
 
@@ -95,4 +98,4 @@ check 25 "Packet rate estimate: (9|10|11)" ${TCPKALI} --ws -m '\{message.marker}
 
 check 26 "." ${TCPKALI} ./tcpkali -1 '\{message.marker}' -m '\{message.marker}'
 
-trap "rm -f ${TMPFILE}" EXIT
+trap 'rm -f ${TMPFILE}' EXIT


### PR DESCRIPTION
If writecomb is on message counter doesn't work right in some cases because we write more than one message at a time. This PR fixes my case but I'm not sure about the following case in tcpkali_engine.c:

```
2132         if(token) {
2133             if(position <= token && token < position + wrote) {
2134                 conn->traffic_ongoing.msgs_sent++;
2135             }
2136         }
```
